### PR TITLE
corrected text-icon alignment

### DIFF
--- a/src/components/iconElement.js
+++ b/src/components/iconElement.js
@@ -19,7 +19,8 @@ const IconElement = (props) => {
   const size = round(props.size);
 
   /* Just to align icon examples with typography */
-  const iconLineHeight = 1.375;
+  const iconLineHeight = 1.35;
+  const textLineHeight = 1.25;
 
   const value = baseScaleUnit === 'px' ? size : round(size / baseSize, 3);
 
@@ -33,6 +34,7 @@ const IconElement = (props) => {
     ''
   );
   const margin = props.showValue ? `${size * iconLineHeight - size}px` : '0px';
+  const minHeight = props.textSize ? props.textSize * textLineHeight : size;
 
   return (
     <div
@@ -47,6 +49,7 @@ const IconElement = (props) => {
         style={{
           width: `${size}px`,
           height: `${size}px`,
+          minHeight: `${minHeight}px`,
         }}
       >
         {createSvgIcon(size, size, iconPadding, `${icon}`, iconStroke)}

--- a/src/components/typeIconPairing.js
+++ b/src/components/typeIconPairing.js
@@ -191,6 +191,7 @@ const TypeIconPairing = (props) => {
           <IconElement
             key={`typeIcon-icon-${iconScale}-${i}`}
             size={iconSize}
+            textSize={textSize}
             i={iconIncrement}
           />
           <span

--- a/src/styles/iconography.css
+++ b/src/styles/iconography.css
@@ -14,4 +14,5 @@
   display: flex;
   background-color: var(--blueprint100);
   border-radius: 2px;
+  align-items: center;
 }

--- a/src/styles/typeIconPair.css
+++ b/src/styles/typeIconPair.css
@@ -12,6 +12,7 @@
 .typeIconPair {
   display: flex;
   flex-direction: row;
+  align-items: start;
 }
 
 .typeIconPair .iconItem,

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -7,6 +7,7 @@
   display: grid;
   grid-template-columns: 64px max-content;
   align-items: center;
+  line-height: 1.25; /* Same value used in iconElement to calculate min height of icon in pairing */
 }
 
 .specs {


### PR DESCRIPTION
Ensured icons are properly aligned when text wraps in the text-icon-pairing examples.